### PR TITLE
Authentication Use Case - Fixed bugs & Code Cleanup

### DIFF
--- a/src/app/AuthenticationUseCaseFactory.java
+++ b/src/app/AuthenticationUseCaseFactory.java
@@ -1,10 +1,11 @@
 package app;
 
 import interface_adapter.Authentication.AuthenticationViewModel;
+import interface_adapter.DisplayDash.DashboardViewModel;
 import interface_adapter.SetupAuth.SetupAuthViewModel;
 import interface_adapter.Authentication.AuthenticationController;
 import interface_adapter.Authentication.AuthenticationPresenter;
-import use_case.Authentication.AuthenticationDataAcessInterface;
+import use_case.Authentication.AuthenticationDataAccessInterface;
 import use_case.Authentication.*;
 import entity.CommonAuthKey;
 import entity.AuthKey;
@@ -19,10 +20,10 @@ public class AuthenticationUseCaseFactory {
     private AuthenticationUseCaseFactory() {}
 
     public static AuthenticationView create(
-            ViewManagerModel viewManagerModel, AuthenticationViewModel authenticationViewModel, AuthenticationDataAccessInterface userDataAccessObject){
+            ViewManagerModel viewManagerModel, AuthenticationViewModel authenticationViewModel, DashboardViewModel dashboardViewModel, AuthenticationDataAccessInterface userDataAccessObject){
 
         try{
-            AuthenticationController authenticationController = createAuthenticationUseCase(viewManagerModel, authenticationViewModel, userDataAccessObject);
+            AuthenticationController authenticationController = createAuthenticationUseCase(viewManagerModel, authenticationViewModel, dashboardViewModel, userDataAccessObject);
             return new AuthenticationView(authenticationViewModel, authenticationController);
         } catch (IOException e) {
             JOptionPane.showMessageDialog(null, "Could not open user data file.");
@@ -31,12 +32,12 @@ public class AuthenticationUseCaseFactory {
         return null;
     }
 
-    private static AuthenticationController createAuthenticationUseCase(ViewManagerModel viewManagerModel, AuthenticationViewModel authenticationViewModel,
+    private static AuthenticationController createAuthenticationUseCase(ViewManagerModel viewManagerModel, AuthenticationViewModel authenticationViewModel, DashboardViewModel dashboardViewModel,
                                                               AuthenticationDataAccessInterface userDataAccessObject) throws IOException{
-        AuthenticationOutputBoundary = new AuthenticationPresenter(viewManagerModel, authenticationViewModel);
+        AuthenticationOutputBoundary authenticationPresenter = new AuthenticationPresenter(viewManagerModel, authenticationViewModel, dashboardViewModel);
 
-        AuthenticationInputBoundary AuthenticationUseCaseInteractor = new AuthenticationUseCaseInteractor(
-                userDataAccessObject, AuthenticationOutputBoundary);
+        AuthenticationInputBoundary AuthenticationUseCaseInteractor = new AuthenticationInteractor(
+                userDataAccessObject, authenticationPresenter);
 
         return new AuthenticationController(AuthenticationUseCaseInteractor);
     }

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -4,6 +4,7 @@ import data_access.FileAuthDataAccessObject;
 import entity.CommonAuthKey;
 import entity.CommonAuthKeyFactory;
 import interface_adapter.Authentication.AuthenticationViewModel;
+import interface_adapter.DisplayDash.DashboardViewModel;
 import interface_adapter.SetupAuth.SetupAuthViewModel;
 import interface_adapter.ViewManagerModel;
 import use_case.SetupAuth.SetupAuthDataAccessInterface;
@@ -36,6 +37,7 @@ public class Main {
 
         SetupAuthViewModel setupAuthViewModel = new SetupAuthViewModel();
         AuthenticationViewModel authenticationViewModel = new AuthenticationViewModel();
+        DashboardViewModel dashboardViewModel = new DashboardViewModel();
 
         FileAuthDataAccessObject userDataAccessObject;
 
@@ -49,11 +51,16 @@ public class Main {
                 userDataAccessObject);
         views.add(setupAuthView, setupAuthView.viewName);
 
-        AuthenticationView authenticationView = AuthenticationUseCaseFactory.create(viewManagerModel, setupAuthViewModel, authenticationViewModel,
+        AuthenticationView authenticationView = AuthenticationUseCaseFactory.create(viewManagerModel, authenticationViewModel, dashboardViewModel,
                 userDataAccessObject);
         views.add(authenticationView, authenticationView.viewName);
 
-        viewManagerModel.setActiveView(setupAuthView.viewName);
+        if (userDataAccessObject.getAuthKey() == null) {
+            viewManagerModel.setActiveView(setupAuthView.viewName);
+        }
+        else {
+            viewManagerModel.setActiveView(authenticationView.viewName);
+        }
         viewManagerModel.firePropertyChanged();
 
         application.pack();

--- a/src/data_access/FileAuthDataAccessObject.java
+++ b/src/data_access/FileAuthDataAccessObject.java
@@ -3,6 +3,7 @@ package data_access;
 import entity.AuthKey;
 import entity.AuthKeyFactory;
 import entity.CommonAuthKey;
+import use_case.Authentication.AuthenticationDataAccessInterface;
 import use_case.SetupAuth.SetupAuthDataAccessInterface;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -12,7 +13,7 @@ import java.io.*;
 public class FileAuthDataAccessObject implements SetupAuthDataAccessInterface, AuthenticationDataAccessInterface {
     private final File csvFile;
 
-    private final AuthKey authKey;
+    private AuthKey authKey;
     private final String salt;
 
     private AuthKeyFactory authKeyFactory;
@@ -58,6 +59,7 @@ public class FileAuthDataAccessObject implements SetupAuthDataAccessInterface, A
      */
     @Override
     public void save(CommonAuthKey authKey) {
+        this.authKey = authKey;
         BufferedWriter writer;
         try {
             writer = new BufferedWriter(new FileWriter(csvFile));

--- a/src/interface_adapter/Authentication/AuthenticationPresenter.java
+++ b/src/interface_adapter/Authentication/AuthenticationPresenter.java
@@ -1,5 +1,7 @@
 package interface_adapter.Authentication;
 
+import interface_adapter.DisplayDash.DashboardState;
+import interface_adapter.DisplayDash.DashboardViewModel;
 import interface_adapter.ViewManagerModel;
 import use_case.Authentication.AuthenticationOutputBoundary;
 import use_case.Authentication.AuthenticationOutputData;

--- a/src/interface_adapter/Authentication/AuthenticationState.java
+++ b/src/interface_adapter/Authentication/AuthenticationState.java
@@ -62,7 +62,6 @@ public class AuthenticationState {
         return "AuthenticationState{" +
                 "password='" + this.password + '\'' +
                 ", passwordError='" + this.passwordError + '\'' +
-                ", repeatPassword='" + this.repeatedPassword + '\'' +
                 '}';
     }
 

--- a/src/interface_adapter/DisplayDash/DashboardState.java
+++ b/src/interface_adapter/DisplayDash/DashboardState.java
@@ -1,0 +1,8 @@
+package interface_adapter.DisplayDash;
+
+public class DashboardState {
+
+    public DashboardState() {
+
+    }
+}

--- a/src/interface_adapter/DisplayDash/DashboardViewModel.java
+++ b/src/interface_adapter/DisplayDash/DashboardViewModel.java
@@ -1,0 +1,31 @@
+package interface_adapter.DisplayDash;
+
+import interface_adapter.Authentication.AuthenticationState;
+import interface_adapter.ViewModel;
+
+import java.beans.PropertyChangeListener;
+
+public class DashboardViewModel extends ViewModel {
+    private DashboardState state = new DashboardState();
+    public DashboardViewModel() {
+        super("display dash");
+    }
+
+    @Override
+    public void firePropertyChanged() {
+
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+
+    }
+
+    public DashboardState getState() {
+        return this.state;
+    }
+
+    public void setState(DashboardState dashboardState) {
+        this.state = dashboardState;
+    }
+}

--- a/src/use_case/Authentication/AuthenticationInteractor.java
+++ b/src/use_case/Authentication/AuthenticationInteractor.java
@@ -27,7 +27,6 @@ public class AuthenticationInteractor implements AuthenticationInputBoundary {
             authenticationPresenter.prepareFailView("Passwords is incorrect.");
         }
         else {
-            SetupAuthOutputData setupAuthOutputData = new SetupAuthOutputData(false);
             authenticationPresenter.prepareSuccessView(new AuthenticationOutputData(true));
         }
     }

--- a/src/view/AuthenticationView.java
+++ b/src/view/AuthenticationView.java
@@ -47,9 +47,8 @@ public class AuthenticationView extends JPanel implements ActionListener, Proper
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(confirmButton)) {
                             AuthenticationState currentState = authenticationViewModel.getState();
-                            authenticationViewModel.execute(
-                                    currentState.getPassword(),
-                                    currentState.getRepeatedPassword()
+                            authenticationController.execute(
+                                    currentState.getPassword()
                             );
                         }
                     }


### PR DESCRIPTION
Fixed various bugs including:
- Correctly checking if an auth key exists to determine whether to display setup auth screen or authentication screen on startup
- Passing through the correct objects/variables in the parameters to constructor calls when instantiating objects in the authetnication use case factory and main class
- Correctly updating the in-memory attribute of the data access object upon saving a new auth key
- Correctly calling the authentication controller's execute method upon clicking the "confirm" button on the authentication screen (previously called the view model's execute method which did not exist/is invalid)

Additionally did some code cleanup by removing unnecessary code which was copy-pasted by mistake and added boilerplate code for some required DisplayDash files (State and View Model) in this use-case.