### PR TITLE
Update account - New Use Case for Updating Account

### DIFF
--- a/src/app/DashboardUseCaseFactory.java
+++ b/src/app/DashboardUseCaseFactory.java
@@ -9,6 +9,8 @@ import interface_adapter.Dashboard.DashboardPresenter;
 import interface_adapter.Dashboard.DashboardViewModel;
 import interface_adapter.LogOut.LogOutController;
 import interface_adapter.LogOut.LogOutPresenter;
+import interface_adapter.UpdateAccount.UpdateAccountController;
+import interface_adapter.UpdateAccount.UpdateAccountViewModel;
 import interface_adapter.ViewManagerModel;
 import use_case.CreateAccount.CreateAccountDataAccessInterface;
 import use_case.CreateAccount.CreateAccountInputBoundary;
@@ -22,6 +24,7 @@ import use_case.LogOut.LogOutDataAccessInterface;
 import use_case.LogOut.LogOutInputBoundary;
 import use_case.LogOut.LogOutInteractor;
 import use_case.LogOut.LogOutOutputBoundary;
+import use_case.UpdateAccount.UpdateAccountDataAccessInterface;
 import view.DashboardView;
 
 public class DashboardUseCaseFactory {
@@ -35,15 +38,17 @@ public class DashboardUseCaseFactory {
     public static DashboardView create(ViewManagerModel viewManagerModel,
                                        AuthenticationViewModel authenticationViewModel,
                                        DashboardViewModel dashboardViewModel, CreateAccountViewModel createAccountViewModel,
-                                       DashboardDataAccessInterface userDataAccessObject) {
+                                       UpdateAccountViewModel updateAccountViewModel, DashboardDataAccessInterface userDataAccessObject) {
         DashboardController dashboardController = createDashboardUseCase(viewManagerModel, dashboardViewModel,
                 userDataAccessObject);
         LogOutController logOutController = createLogOutUseCase(viewManagerModel, authenticationViewModel,
                 (LogOutDataAccessInterface) userDataAccessObject);
         CreateAccountController createAccountController = createCreateAccountUseCase(viewManagerModel, createAccountViewModel,
                 dashboardViewModel, (CreateAccountDataAccessInterface) userDataAccessObject);
+        UpdateAccountController updateAccountController = UpdateAccountUseCaseFactory.createUpdateAccountUseCase(viewManagerModel,
+                updateAccountViewModel, dashboardViewModel, (UpdateAccountDataAccessInterface) userDataAccessObject);
         return new DashboardView(dashboardViewModel, dashboardController, logOutController, createAccountController,
-                createAccountViewModel);
+                createAccountViewModel, updateAccountController, updateAccountViewModel);
     }
 
     /**

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -9,6 +9,7 @@ import interface_adapter.CreateAccount.CreateAccountController;
 import interface_adapter.CreateAccount.CreateAccountViewModel;
 import interface_adapter.Dashboard.DashboardViewModel;
 import interface_adapter.SetupAuth.SetupAuthViewModel;
+import interface_adapter.UpdateAccount.UpdateAccountViewModel;
 import interface_adapter.ViewManagerModel;
 import view.*;
 
@@ -42,6 +43,7 @@ public class Main {
         AuthenticationViewModel authenticationViewModel = new AuthenticationViewModel();
         DashboardViewModel dashboardViewModel = new DashboardViewModel();
         CreateAccountViewModel createAccountViewModel = new CreateAccountViewModel();
+        UpdateAccountViewModel updateAccountViewModel = new UpdateAccountViewModel();
 
         FileAuthDataAccessObject authDataAccessObject;
         FileDashDataAccessObject dashDataAccessObject;
@@ -70,7 +72,7 @@ public class Main {
         views.add(authenticationView, authenticationView.viewName);
 
         DashboardView dashboardView = DashboardUseCaseFactory.create(viewManagerModel, authenticationViewModel,
-                dashboardViewModel, createAccountViewModel, dashDataAccessObject);
+                dashboardViewModel, createAccountViewModel, updateAccountViewModel, dashDataAccessObject);
         views.add(dashboardView, dashboardView.viewName);
 
 

--- a/src/app/UpdateAccountUseCaseFactory.java
+++ b/src/app/UpdateAccountUseCaseFactory.java
@@ -1,0 +1,29 @@
+package app;
+
+import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.UpdateAccount.UpdateAccountController;
+import interface_adapter.UpdateAccount.UpdateAccountPresenter;
+import interface_adapter.UpdateAccount.UpdateAccountViewModel;
+import interface_adapter.ViewManagerModel;
+import use_case.UpdateAccount.*;
+
+public class UpdateAccountUseCaseFactory {
+    /**
+     * method which creates and returns a new controller for the Update Account use case
+     * @param viewManagerModel view manager model
+     * @param updateAccountViewModel view model for updateAccount
+     * @param dashboardViewModel  view model for dashboard view
+     * @param userDataAccessObject DAO for dashboard/updateAccount
+     * @return a new controller for the UpdateAccount use case
+     */
+    public static UpdateAccountController createUpdateAccountUseCase(ViewManagerModel viewManagerModel,
+                                                                      UpdateAccountViewModel updateAccountViewModel, DashboardViewModel dashboardViewModel,
+                                                                      UpdateAccountDataAccessInterface userDataAccessObject) {
+        UpdateAccountOutputBoundary updateAccountPresenter = new UpdateAccountPresenter(viewManagerModel, updateAccountViewModel, dashboardViewModel);
+
+        UpdateAccountInputBoundary updateAccountUseCaseInteractor = new UpdateAccountInteractor(userDataAccessObject, updateAccountPresenter);
+
+        return new UpdateAccountController(updateAccountUseCaseInteractor);
+    }
+}
+

--- a/src/data_access/FileDashDataAccessObject.java
+++ b/src/data_access/FileDashDataAccessObject.java
@@ -101,13 +101,13 @@ public class FileDashDataAccessObject implements DashboardDataAccessInterface, L
      * @param updatedDate
      * @param updatedNotes
      */
-    public void updateAccount(int index, String updatedTitle, String updatedUsername, String updatedPassword,
+    public void updateAccount(String originalTitle, String originalUser, String updatedTitle, String updatedUsername, String updatedPassword,
                               String updatedKey, String updatedURL, String updatedIconURL,
                               String updatedDate, String updatedNotes) {
         String sql = "UPDATE password_manager_data " +
                 "SET title = ?, username = ?, password = ?, two_factor_secret_key = ?, " +
                 "url = ?, icon_url = ?, date = ?, notes = ? " +
-                "WHERE id = ?";
+                "WHERE title = ? AND username = ?";
 
         try (PreparedStatement statement = CONNECTION.prepareStatement(sql)) {
             statement.setString(1, encrypt(updatedTitle, this.encryptionKey));
@@ -118,7 +118,8 @@ public class FileDashDataAccessObject implements DashboardDataAccessInterface, L
             statement.setString(6, encrypt(updatedIconURL, this.encryptionKey));
             statement.setString(7, encrypt(updatedDate, this.encryptionKey));
             statement.setString(8, encrypt(updatedNotes, this.encryptionKey));
-            statement.setInt(9, index + 1); // Assuming 'id' starts from 1
+            statement.setString(9, encrypt(originalTitle, this.encryptionKey));
+            statement.setString(10, encrypt(originalUser, this.encryptionKey));
 
             statement.executeUpdate();
         } catch (SQLException e) {

--- a/src/data_access/FileDashDataAccessObject.java
+++ b/src/data_access/FileDashDataAccessObject.java
@@ -5,6 +5,7 @@ import entity.AccountInfoFactory;
 import use_case.CreateAccount.CreateAccountDataAccessInterface;
 import use_case.Dashboard.DashboardDataAccessInterface;
 import use_case.LogOut.LogOutDataAccessInterface;
+import use_case.UpdateAccount.UpdateAccountDataAccessInterface;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -18,7 +19,8 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
-public class FileDashDataAccessObject implements DashboardDataAccessInterface, LogOutDataAccessInterface, CreateAccountDataAccessInterface {
+public class FileDashDataAccessObject implements DashboardDataAccessInterface, LogOutDataAccessInterface, CreateAccountDataAccessInterface
+, UpdateAccountDataAccessInterface {
     private static final String ALGORITHM = "AES";
     private static final String TRANSFORMATION = "AES/ECB/PKCS5Padding";
     private final AccountInfoFactory ACCOUNTFACTORY;
@@ -80,6 +82,43 @@ public class FileDashDataAccessObject implements DashboardDataAccessInterface, L
             statement.setString(7, encrypt(account.getIconURL(), this.encryptionKey));
             statement.setString(8, encrypt(account.getDate(), this.encryptionKey));
             statement.setString(9, encrypt(account.getNotes(), this.encryptionKey));
+
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * method to update the account's changes in the database
+     * @param index
+     * @param updatedTitle
+     * @param updatedUsername
+     * @param updatedPassword
+     * @param updatedKey
+     * @param updatedURL
+     * @param updatedIconURL
+     * @param updatedDate
+     * @param updatedNotes
+     */
+    public void updateAccount(int index, String updatedTitle, String updatedUsername, String updatedPassword,
+                              String updatedKey, String updatedURL, String updatedIconURL,
+                              String updatedDate, String updatedNotes) {
+        String sql = "UPDATE password_manager_data " +
+                "SET title = ?, username = ?, password = ?, two_factor_secret_key = ?, " +
+                "url = ?, icon_url = ?, date = ?, notes = ? " +
+                "WHERE id = ?";
+
+        try (PreparedStatement statement = CONNECTION.prepareStatement(sql)) {
+            statement.setString(1, encrypt(updatedTitle, this.encryptionKey));
+            statement.setString(2, encrypt(updatedUsername, this.encryptionKey));
+            statement.setString(3, encrypt(updatedPassword, this.encryptionKey));
+            statement.setString(4, encrypt(updatedKey, this.encryptionKey));
+            statement.setString(5, encrypt(updatedURL, this.encryptionKey));
+            statement.setString(6, encrypt(updatedIconURL, this.encryptionKey));
+            statement.setString(7, encrypt(updatedDate, this.encryptionKey));
+            statement.setString(8, encrypt(updatedNotes, this.encryptionKey));
+            statement.setInt(9, index + 1); // Assuming 'id' starts from 1
 
             statement.executeUpdate();
         } catch (SQLException e) {

--- a/src/interface_adapter/UpdateAccount/UpdateAccountController.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountController.java
@@ -20,10 +20,10 @@ public class UpdateAccountController {
     /**
      * Method which is executed/triggered when the user enters the updateAccount view
      */
-    public void execute(int accountIndex, String title, String username, String password, String secretKey, String url,
+    public void execute(String originaltitle, String originaluser, String title, String username, String password, String secretKey, String url,
                         String iconURL, LocalDateTime date, String notes) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        UpdateAccountInputData updateAccountInputData = new UpdateAccountInputData(accountIndex, title, username, password,
+        UpdateAccountInputData updateAccountInputData = new UpdateAccountInputData(originaltitle, originaluser, title, username, password,
                 secretKey, url, iconURL, formatter.format(date), notes);
         updateAccountInteractor.execute(updateAccountInputData);
     }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountController.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountController.java
@@ -1,0 +1,4 @@
+package interface_adapter.UpdateAccount;
+
+public class UpdateAccountController {
+}

--- a/src/interface_adapter/UpdateAccount/UpdateAccountController.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountController.java
@@ -1,4 +1,34 @@
 package interface_adapter.UpdateAccount;
 
+import use_case.UpdateAccount.UpdateAccountInputBoundary;
+import use_case.UpdateAccount.UpdateAccountInputData;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class UpdateAccountController {
+    public final UpdateAccountInputBoundary updateAccountInteractor;
+
+    /**
+     * Constructor method for the controller for the updateAccount use case
+     * @param updateAccountInteractor The use case interactor object for the updateAccount use case
+     */
+    public UpdateAccountController(UpdateAccountInputBoundary updateAccountInteractor) {
+        this.updateAccountInteractor = updateAccountInteractor;
+    }
+
+    /**
+     * Method which is executed/triggered when the user enters the updateAccount view
+     */
+    public void execute(int accountIndex, String title, String username, String password, String secretKey, String url,
+                        String iconURL, LocalDateTime date, String notes) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        UpdateAccountInputData updateAccountInputData = new UpdateAccountInputData(accountIndex, title, username, password,
+                secretKey, url, iconURL, formatter.format(date), notes);
+        updateAccountInteractor.execute(updateAccountInputData);
+    }
+
+    public void switchView(){
+        updateAccountInteractor.switchView();
+    }
 }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
@@ -1,4 +1,58 @@
 package interface_adapter.UpdateAccount;
 
-public class UpdateAccountPresenter {
+import interface_adapter.Dashboard.DashboardState;
+import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.ViewManagerModel;
+import use_case.UpdateAccount.UpdateAccountOutputBoundary;
+import use_case.UpdateAccount.UpdateAccountOutputData;
+
+public class UpdateAccountPresenter implements UpdateAccountOutputBoundary {
+    private final UpdateAccountViewModel updateAccountViewModel;
+    private final DashboardViewModel dashboardViewModel;
+    private final ViewManagerModel viewManagerModel;
+
+
+    /**
+     * Constructor method for the UpdateAccount use case's presenter
+     * @param updateAccountViewModel The view model for the UpdateAccount view
+     * @param dashboardViewModel The view model for the dashboard view
+     */
+    public UpdateAccountPresenter(ViewManagerModel viewManagerModel,
+                                  UpdateAccountViewModel updateAccountViewModel,
+                                  DashboardViewModel dashboardViewModel) {
+        this.updateAccountViewModel = updateAccountViewModel;
+        this.dashboardViewModel = dashboardViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
+
+    /**
+     * Method which updates the view manager model to display the dashboard screen after updateAccount is complete
+     * @param updateAccountOutputData The UpdateAccount use case output data
+     */
+    @Override
+    public void prepareSuccessView(UpdateAccountOutputData updateAccountOutputData) {
+        DashboardState dashboardState = dashboardViewModel.getState();
+        dashboardState.setAccounts(updateAccountOutputData.getAccounts());
+        dashboardViewModel.setState(dashboardState);
+
+        switchView();
+    }
+
+    /**
+     * Method which updates the view manager model to display the failed updateAccount screen
+     * @param error The error message which explains why updating an account failed
+     */
+    @Override
+    public void prepareFailView(String error) {
+        UpdateAccountState updateAccountState = updateAccountViewModel.getState();
+        updateAccountState.setUsernameError(error);
+        this.updateAccountViewModel.firePropertyChanged();
+    }
+
+    public void switchView(){
+        DashboardState dashboardState = dashboardViewModel.getState();
+        dashboardState.setRightPanelView("dashboard");
+        dashboardViewModel.setState(dashboardState);
+        this.dashboardViewModel.firePropertyChanged();
+    }
 }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
@@ -31,9 +31,10 @@ public class UpdateAccountPresenter implements UpdateAccountOutputBoundary {
      */
     @Override
     public void prepareSuccessView(UpdateAccountOutputData updateAccountOutputData) {
-        DashboardState dashboardState = dashboardViewModel.getState();
-        dashboardState.setAccounts(updateAccountOutputData.getAccounts());
-        dashboardViewModel.setState(dashboardState);
+        UpdateAccountState state = updateAccountViewModel.getState();
+        state.setUsernameError(null);
+        updateAccountViewModel.setState(state);
+        updateAccountViewModel.firePropertyChanged();
 
         switchView();
     }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountPresenter.java
@@ -1,0 +1,4 @@
+package interface_adapter.UpdateAccount;
+
+public class UpdateAccountPresenter {
+}

--- a/src/interface_adapter/UpdateAccount/UpdateAccountState.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountState.java
@@ -1,4 +1,236 @@
 package interface_adapter.UpdateAccount;
 
+import entity.AccountInfo;
+import interface_adapter.CreateAccount.CreateAccountState;
+
+import java.util.List;
+
 public class UpdateAccountState {
+    private List<AccountInfo> accounts;
+    private int accountIndex;
+    private String title = "";
+    private String username = "";
+    private String usernameError = null;
+    private String password = "";
+    private String secretKey = "";
+    private String url = "";
+    private String iconURL = "";
+    private String date;
+    private String notes = "";
+
+
+    /**
+     * Constructor method for the UpdateAccount's view state
+     * @param copy a copy of the Update Account state
+     */
+    public UpdateAccountState(UpdateAccountState copy) {
+        this.accounts = copy.accounts;
+        this.title = copy.title;
+        this.username = copy.username;
+        this.usernameError = copy.usernameError;
+        this.password = copy.password;
+        this.secretKey = copy.secretKey;
+        this.url = copy.url;
+        this.iconURL = copy.iconURL;
+        this.date = copy.date;
+        this.notes = copy.notes;
+    }
+
+    /**
+     * Alternative constructor method for the UpdateAccount state for no copy
+     * which keeps attributes initialized as null/empty strings
+     */
+    public UpdateAccountState() {
+    }
+
+    /**
+     * Getter method for the user's accounts
+     * @return The user's accounts
+     */
+    public List<AccountInfo> getAccounts() { return this.accounts; }
+
+
+    /**
+     * Setter method for the user's accounts
+     * @param accounts the user's accounts
+     */
+    public void setAccounts(List<AccountInfo> accounts){this.accounts = accounts;}
+
+    /**
+     * Getter method for the accountIndex of the account.
+     *
+     * @return The accountIndex of the account.
+     */
+    public int getAccountIndex() {
+        return this.accountIndex;
+    }
+
+    /**
+     * Setter method for the accountIndex of the account.
+     *
+     * @param index The new accountIndex for the account.
+     */
+    public void setAccountIndex(int index) {
+        this.accountIndex= index;
+    }
+
+    /**
+     * Getter method for the title of the account.
+     *
+     * @return The title of the account.
+     */
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Setter method for the title of the account.
+     *
+     * @param title The new title for the account.
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * Getter method for the username associated with the account.
+     *
+     * @return The username of the account.
+     */
+    public String getUsername() {
+        return this.username;
+    }
+
+    /**
+     * Setter method for the username associated with the account.
+     *
+     * @param username The new username for the account.
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * Getter method for the username error
+     * @return The error message to be displayed for createAccount failure due to username
+     */
+    public String getUsernameError() {
+        return this.usernameError;
+    }
+
+    /**
+     * Setter method for the username error
+     * @param error The error message to be set for a createAccount failure due to username
+     */
+    public void setUsernameError(String error) {
+        this.usernameError = error;
+    }
+
+    /**
+     * Getter method for the password of the account.
+     *
+     * @return The password of the account.
+     */
+    public String getPassword() {
+        return this.password;
+    }
+
+    /**
+     * Setter method for the password of the account.
+     *
+     * @param password The new password for the account.
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * Getter method for the secret key associated with the account.
+     *
+     * @return The secret key of the account.
+     */
+    public String getSecretKey() {
+        return this.secretKey;
+    }
+
+    /**
+     * Setter method for the secret key associated with the account.
+     *
+     * @param secretKey The new secret key for the account.
+     */
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    /**
+     * Getter method for the URL associated with the account.
+     *
+     * @return The URL of the account.
+     */
+    public String getURL() {
+        return this.url;
+    }
+
+    /**
+     * Setter method for the URL associated with the account.
+     *
+     * @param url The new URL for the account.
+     */
+    public void setURL(String url) {
+        this.url = url;
+    }
+
+    /**
+     * Getter method for the URL of the icon associated with the account.
+     *
+     * @return The URL of the icon.
+     */
+    public String getIconURL() {
+        return this.iconURL;
+    }
+
+    /**
+     * Setter method for the URL of the icon associated with the account.
+     *
+     * @param iconURL The new URL for the icon.
+     */
+    public void setIconURL(String iconURL) {
+        this.iconURL = iconURL;
+    }
+
+    /**
+     * Getter method for the date when the account information was last updated.
+     *
+     * @return The date of the last update.
+     */
+    public String getDate() {
+        return this.date;
+    }
+
+    /**
+     * Setter method for the date when the account information was last updated.
+     *
+     * @param date The new date of the last update.
+     */
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    /**
+     * Getter method for any additional notes or information related to the account.
+     *
+     * @return Additional notes or information about the account.
+     */
+    public String getNotes() {
+        return this.notes;
+    }
+
+    /**
+     * Setter method for any additional notes or information related to the account.
+     *
+     * @param notes The new notes for the account.
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
 }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountState.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountState.java
@@ -8,6 +8,8 @@ import java.util.List;
 public class UpdateAccountState {
     private List<AccountInfo> accounts;
     private int accountIndex;
+    private String originalTitle = "";
+    private String originalUser = "";
     private String title = "";
     private String username = "";
     private String usernameError = null;
@@ -25,6 +27,8 @@ public class UpdateAccountState {
      */
     public UpdateAccountState(UpdateAccountState copy) {
         this.accounts = copy.accounts;
+        this.originalTitle = copy.originalTitle;
+        this.originalUser = copy.originalUser;
         this.title = copy.title;
         this.username = copy.username;
         this.usernameError = copy.usernameError;
@@ -61,8 +65,8 @@ public class UpdateAccountState {
      *
      * @return The accountIndex of the account.
      */
-    public int getAccountIndex() {
-        return this.accountIndex;
+    public String getOriginalTitle() {
+        return this.originalTitle;
     }
 
     /**
@@ -70,8 +74,26 @@ public class UpdateAccountState {
      *
      * @param index The new accountIndex for the account.
      */
-    public void setAccountIndex(int index) {
-        this.accountIndex= index;
+    public void setOriginalTitle(String originalTitle) {
+        this.originalTitle= originalTitle;
+    }
+
+    /**
+     * Getter method for the accountIndex of the account.
+     *
+     * @return The accountIndex of the account.
+     */
+    public String getOriginalUser() {
+        return this.originalUser;
+    }
+
+    /**
+     * Setter method for the accountIndex of the account.
+     *
+     * @param index The new accountIndex for the account.
+     */
+    public void setOriginalUser(String originalUser) {
+        this.originalUser= originalUser;
     }
 
     /**

--- a/src/interface_adapter/UpdateAccount/UpdateAccountState.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountState.java
@@ -1,0 +1,4 @@
+package interface_adapter.UpdateAccount;
+
+public class UpdateAccountState {
+}

--- a/src/interface_adapter/UpdateAccount/UpdateAccountViewModel.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountViewModel.java
@@ -1,4 +1,52 @@
 package interface_adapter.UpdateAccount;
 
-public class UpdateAccountViewModel {
+import interface_adapter.CreateAccount.CreateAccountState;
+import interface_adapter.ViewModel;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+public class UpdateAccountViewModel extends ViewModel {
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
+    private UpdateAccountState state = new UpdateAccountState();
+
+    /**
+     * Constructor method for the UpdateAccount view's view model
+     */
+    public UpdateAccountViewModel() {
+        super("update account");
+    }
+
+    /**
+     * method which triggers/executes when the state changes
+     */
+    @Override
+    public void firePropertyChanged() {
+        support.firePropertyChange("state", null, this.state);
+    }
+
+    /**
+     * Method which adds a PropertyChangeListener to the view model
+     * @param listener The PropertyChangeListener to be added
+     */
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        support.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * Getter method for the UpdateAccount view model's state
+     * @return The UpdateAccount view model's state
+     */
+    public UpdateAccountState getState() {
+        return this.state;
+    }
+
+    /**
+     * Setter method for the UpdateAccount view model's state
+     * @param updateAccountState The state to be set
+     */
+    public void setState(UpdateAccountState updateAccountState) {
+        this.state = updateAccountState;
+    }
 }

--- a/src/interface_adapter/UpdateAccount/UpdateAccountViewModel.java
+++ b/src/interface_adapter/UpdateAccount/UpdateAccountViewModel.java
@@ -1,0 +1,4 @@
+package interface_adapter.UpdateAccount;
+
+public class UpdateAccountViewModel {
+}

--- a/src/use_case/CreateAccount/CreateAccountOutputBoundary.java
+++ b/src/use_case/CreateAccount/CreateAccountOutputBoundary.java
@@ -3,7 +3,7 @@ package use_case.CreateAccount;
 public interface CreateAccountOutputBoundary {
     /**
      * Method which updates the view manager model to display the Dashboard screen after CreateAccount is complete
-     * @param createAccountOutputData The SetupAuth use case output data
+     * @param createAccountOutputData The CreateAccount use case output data
      */
     void prepareSuccessView(CreateAccountOutputData createAccountOutputData);
 

--- a/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
+++ b/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
@@ -1,4 +1,28 @@
 package use_case.UpdateAccount;
 
+import entity.AccountInfo;
+
+import java.util.List;
+
 public interface UpdateAccountDataAccessInterface {
+    /**
+     * Method gets all the currently signed in user's accounts
+     * @return returns list of user's accounts
+     */
+    List<AccountInfo> getAccounts();
+
+    /**
+     * method that updates the information in the selected account
+     * @param accountIndex
+     * @param title
+     * @param username
+     * @param password
+     * @param secret
+     * @param url
+     * @param iconURL
+     * @param date
+     * @param notes
+     */
+    void updateAccount(int accountIndex, String title, String username, String password, String secret, String url,
+                    String iconURL, String date, String notes);
 }

--- a/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
+++ b/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public interface UpdateAccountDataAccessInterface {
+}

--- a/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
+++ b/src/use_case/UpdateAccount/UpdateAccountDataAccessInterface.java
@@ -23,6 +23,6 @@ public interface UpdateAccountDataAccessInterface {
      * @param date
      * @param notes
      */
-    void updateAccount(int accountIndex, String title, String username, String password, String secret, String url,
+    void updateAccount(String originalTitle, String originalUser, String title, String username, String password, String secret, String url,
                     String iconURL, String date, String notes);
 }

--- a/src/use_case/UpdateAccount/UpdateAccountInputBoundary.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInputBoundary.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public interface UpdateAccountInputBoundary {
+}

--- a/src/use_case/UpdateAccount/UpdateAccountInputBoundary.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInputBoundary.java
@@ -1,4 +1,11 @@
 package use_case.UpdateAccount;
 
 public interface UpdateAccountInputBoundary {
+    /**
+     * Method which contains the logic for the UpdateAccount use case (interactor) which is triggered to complete use case
+     * @param updateAccountInputData The input data for the use case interactor
+     */
+    void execute(UpdateAccountInputData updateAccountInputData);
+
+    void switchView();
 }

--- a/src/use_case/UpdateAccount/UpdateAccountInputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInputData.java
@@ -1,7 +1,8 @@
 package use_case.UpdateAccount;
 
 public class UpdateAccountInputData {
-    final private int accountIndex;
+    final private String originalTitle;
+    final private String originalUser;
     final private String title;
     final private String username;
     final private String password;
@@ -23,9 +24,10 @@ public class UpdateAccountInputData {
      * @param date The last modified date of the account
      * @param notes The notes for the account
      */
-    public UpdateAccountInputData(int accountIndex, String title, String username, String password, String secretKey,
+    public UpdateAccountInputData(String originalTitle, String originalUser, String title, String username, String password, String secretKey,
                                   String url, String iconURL, String date, String notes) {
-        this.accountIndex = accountIndex;
+        this.originalTitle = originalTitle;
+        this.originalUser = originalUser;
         this.title = title;
         this.username = username;
         this.password = password;
@@ -38,12 +40,21 @@ public class UpdateAccountInputData {
 
 
     /**
-     * Getter method for the title of the account.
+     * Getter method for the original title of the account.
      *
      * @return The title of the account.
      */
-    public int getAccountIndex() {
-        return this.accountIndex;
+    public String getOriginalTitle() {
+        return this.originalTitle;
+    }
+
+    /**
+     * Getter method for the original user of the account.
+     *
+     * @return The title of the account.
+     */
+    public String getOriginalUser() {
+        return this.originalUser;
     }
 
     /**

--- a/src/use_case/UpdateAccount/UpdateAccountInputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInputData.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public class UpdateAccountInputData {
+}

--- a/src/use_case/UpdateAccount/UpdateAccountInputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInputData.java
@@ -1,4 +1,120 @@
 package use_case.UpdateAccount;
 
 public class UpdateAccountInputData {
+    final private int accountIndex;
+    final private String title;
+    final private String username;
+    final private String password;
+    final private String secretKey;
+    final private String url;
+    final private String iconURL;
+    final private String date;
+    final private String notes;
+
+    /**
+     * Constructor method for the CreateAccount use case's input data
+     * @param accountIndex the index of the account selected in the table
+     * @param title The title of the account
+     * @param username The username of the account
+     * @param password The password of the account
+     * @param secretKey The 2FA secret key of the account
+     * @param url The URL of the account
+     * @param iconURL The URL for the icon of the account
+     * @param date The last modified date of the account
+     * @param notes The notes for the account
+     */
+    public UpdateAccountInputData(int accountIndex, String title, String username, String password, String secretKey,
+                                  String url, String iconURL, String date, String notes) {
+        this.accountIndex = accountIndex;
+        this.title = title;
+        this.username = username;
+        this.password = password;
+        this.secretKey = secretKey;
+        this.url = url;
+        this.iconURL = iconURL;
+        this.date = date;
+        this.notes = notes;
+    }
+
+
+    /**
+     * Getter method for the title of the account.
+     *
+     * @return The title of the account.
+     */
+    public int getAccountIndex() {
+        return this.accountIndex;
+    }
+
+    /**
+     * Getter method for the title of the account.
+     *
+     * @return The title of the account.
+     */
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Getter method for the username associated with the account.
+     *
+     * @return The username of the account.
+     */
+    public String getUsername() {
+        return this.username;
+    }
+
+    /**
+     * Getter method for the password of the account.
+     *
+     * @return The password of the account.
+     */
+    public String getPassword() {
+        return this.password;
+    }
+
+    /**
+     * Getter method for the secret key associated with the account.
+     *
+     * @return The secret key of the account.
+     */
+    public String getSecretKey() {
+        return this.secretKey;
+    }
+
+    /**
+     * Getter method for the URL associated with the account.
+     *
+     * @return The URL of the account.
+     */
+    public String getURL() {
+        return this.url;
+    }
+
+    /**
+     * Getter method for the URL of the icon associated with the account.
+     *
+     * @return The URL of the icon.
+     */
+    public String getIconURL() {
+        return this.iconURL;
+    }
+
+    /**
+     * Getter method for the date when the account information was last updated.
+     *
+     * @return The date of the last update.
+     */
+    public String getDate() {
+        return this.date;
+    }
+
+    /**
+     * Getter method for any additional notes or information related to the account.
+     *
+     * @return Additional notes or information about the account.
+     */
+    public String getNotes() {
+        return this.notes;
+    }
 }

--- a/src/use_case/UpdateAccount/UpdateAccountInteractor.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInteractor.java
@@ -23,7 +23,8 @@ public class UpdateAccountInteractor implements  UpdateAccountInputBoundary{
      */
     @Override
     public void execute(UpdateAccountInputData updateAccountInputData) {
-        boolean duplicate = isDuplicateAccount(updateAccountInputData.getTitle(), updateAccountInputData.getUsername());
+        boolean duplicate = isDuplicateAccount(updateAccountInputData.getTitle(), updateAccountInputData.getUsername(),
+                updateAccountInputData.getOriginalTitle(), updateAccountInputData.getOriginalUser());
         if (duplicate){
             updateAccountPresenter.prepareFailView("Duplicate Account found");
         }
@@ -44,10 +45,11 @@ public class UpdateAccountInteractor implements  UpdateAccountInputBoundary{
      * @param username The username of the account to be checked
      * @return true if a duplicate account is found, false otherwise
      */
-    public boolean isDuplicateAccount(String title, String username) {
+    public boolean isDuplicateAccount(String title, String username, String originalTitle, String originalUsername) {
         // Check for duplicate title and username combination
         for (AccountInfo account : userDataAccessObject.getAccounts()) {
-            if (account.getTitle().equals(title) && account.getUsername().equals(username)) {
+            if (account.getTitle().equals(title) && account.getUsername().equals(username) &&
+            !(account.getTitle().equals(originalTitle) && account.getUsername().equals(originalUsername))) {
                 return true; // Duplicate title and username combination found
             }
         }

--- a/src/use_case/UpdateAccount/UpdateAccountInteractor.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInteractor.java
@@ -26,10 +26,10 @@ public class UpdateAccountInteractor implements  UpdateAccountInputBoundary{
         boolean duplicate = isDuplicateAccount(updateAccountInputData.getTitle(), updateAccountInputData.getUsername());
         if (duplicate){
             updateAccountPresenter.prepareFailView("Duplicate Account found");
-        } else if (updateAccountInputData.getAccountIndex() == -1) {
-            updateAccountPresenter.prepareFailView("No account selected");
-        } else {
-            userDataAccessObject.updateAccount(updateAccountInputData.getAccountIndex(), updateAccountInputData.getTitle(), updateAccountInputData.getUsername(),
+        }
+        else {
+            userDataAccessObject.updateAccount(updateAccountInputData.getOriginalTitle(),
+                    updateAccountInputData.getOriginalUser(), updateAccountInputData.getTitle(), updateAccountInputData.getUsername(),
                     updateAccountInputData.getPassword(), updateAccountInputData.getSecretKey(), updateAccountInputData.getURL(),
                     updateAccountInputData.getIconURL(), updateAccountInputData.getDate(), updateAccountInputData.getNotes());
             UpdateAccountOutputData updateAccoutOutputData = new UpdateAccountOutputData(true, userDataAccessObject.getAccounts());

--- a/src/use_case/UpdateAccount/UpdateAccountInteractor.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInteractor.java
@@ -1,4 +1,60 @@
 package use_case.UpdateAccount;
 
-public class UpdateAccountInteractor {
+import entity.AccountInfo;
+
+public class UpdateAccountInteractor implements  UpdateAccountInputBoundary{
+    final private UpdateAccountDataAccessInterface userDataAccessObject;
+    final private UpdateAccountOutputBoundary updateAccountPresenter;
+
+    /**
+     * Constructor method for the use case interactor for the UpdateAccount use case
+     * @param userDataAccessObject The data access object which provides access to the stored data required
+     * @param updateAccountPresenter The presenter for the UpdateAccount use case
+     */
+    public UpdateAccountInteractor(UpdateAccountDataAccessInterface userDataAccessObject,
+                                   UpdateAccountOutputBoundary updateAccountPresenter) {
+        this.userDataAccessObject = userDataAccessObject;
+        this.updateAccountPresenter = updateAccountPresenter;
+    }
+
+    /**
+     * Method which contains the logic for the UpdateAccount use case (interactor) which is triggered to complete use case
+     * @param updateAccountInputData input data for the UpdateAccount use case
+     */
+    @Override
+    public void execute(UpdateAccountInputData updateAccountInputData) {
+        boolean duplicate = isDuplicateAccount(updateAccountInputData.getTitle(), updateAccountInputData.getUsername());
+        if (duplicate){
+            updateAccountPresenter.prepareFailView("Duplicate Account found");
+        }
+        else {
+            userDataAccessObject.updateAccount(updateAccountInputData.getAccountIndex(), updateAccountInputData.getTitle(), updateAccountInputData.getUsername(),
+                    updateAccountInputData.getPassword(), updateAccountInputData.getSecretKey(), updateAccountInputData.getURL(),
+                    updateAccountInputData.getIconURL(), updateAccountInputData.getDate(), updateAccountInputData.getNotes());
+            UpdateAccountOutputData updateAccoutOutputData = new UpdateAccountOutputData(true, userDataAccessObject.getAccounts());
+            updateAccountPresenter.prepareSuccessView(updateAccoutOutputData);
+        }
+    }
+
+    /**
+     * Check if an account with the same title and username combination already exists
+     *
+     * @param title    The title of the account to be checked
+     * @param username The username of the account to be checked
+     * @return true if a duplicate account is found, false otherwise
+     */
+    public boolean isDuplicateAccount(String title, String username) {
+        // Check for duplicate title and username combination
+        for (AccountInfo account : userDataAccessObject.getAccounts()) {
+            if (account.getTitle().equals(title) && account.getUsername().equals(username)) {
+                return true; // Duplicate title and username combination found
+            }
+        }
+
+        return false; // No duplicate found
+    }
+
+    public void switchView(){
+        updateAccountPresenter.switchView();
+    }
 }

--- a/src/use_case/UpdateAccount/UpdateAccountInteractor.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInteractor.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public class UpdateAccountInteractor {
+}

--- a/src/use_case/UpdateAccount/UpdateAccountInteractor.java
+++ b/src/use_case/UpdateAccount/UpdateAccountInteractor.java
@@ -26,8 +26,9 @@ public class UpdateAccountInteractor implements  UpdateAccountInputBoundary{
         boolean duplicate = isDuplicateAccount(updateAccountInputData.getTitle(), updateAccountInputData.getUsername());
         if (duplicate){
             updateAccountPresenter.prepareFailView("Duplicate Account found");
-        }
-        else {
+        } else if (updateAccountInputData.getAccountIndex() == -1) {
+            updateAccountPresenter.prepareFailView("No account selected");
+        } else {
             userDataAccessObject.updateAccount(updateAccountInputData.getAccountIndex(), updateAccountInputData.getTitle(), updateAccountInputData.getUsername(),
                     updateAccountInputData.getPassword(), updateAccountInputData.getSecretKey(), updateAccountInputData.getURL(),
                     updateAccountInputData.getIconURL(), updateAccountInputData.getDate(), updateAccountInputData.getNotes());

--- a/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
+++ b/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
@@ -1,13 +1,11 @@
 package use_case.UpdateAccount;
 
-import use_case.CreateAccount.CreateAccountOutputData;
-
 public interface UpdateAccountOutputBoundary {
     /**
      * Method which updates the view manager model to display the Dashboard screen after UpdateAccount is complete
-     * @param updateAccoutOutputData The updateAccount use case output data
+     * @param updateAccountOutputData The updateAccount use case output data
      */
-    void prepareSuccessView(UpdateAccoutOutputData updateAccoutOutputData);
+    void prepareSuccessView(UpdateAccountOutputData updateAccountOutputData);
 
     /**
      * Method which updates the view manager model to display the failed UpdateAccount screen

--- a/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
+++ b/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
@@ -1,4 +1,19 @@
 package use_case.UpdateAccount;
 
+import use_case.CreateAccount.CreateAccountOutputData;
+
 public interface UpdateAccountOutputBoundary {
+    /**
+     * Method which updates the view manager model to display the Dashboard screen after UpdateAccount is complete
+     * @param updateAccoutOutputData The updateAccount use case output data
+     */
+    void prepareSuccessView(UpdateAccoutOutputData updateAccoutOutputData);
+
+    /**
+     * Method which updates the view manager model to display the failed UpdateAccount screen
+     * @param error The error message which explains why UpdateAccount failed
+     */
+    void prepareFailView(String error);
+
+    void switchView();
 }

--- a/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
+++ b/src/use_case/UpdateAccount/UpdateAccountOutputBoundary.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public interface UpdateAccountOutputBoundary {
+}

--- a/src/use_case/UpdateAccount/UpdateAccountOutputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccountOutputData.java
@@ -1,0 +1,23 @@
+package use_case.UpdateAccount;
+
+import entity.AccountInfo;
+
+import java.util.List;
+
+public class UpdateAccountOutputData {
+    private final boolean useCaseFailed;
+    private List<AccountInfo> accounts;
+
+    /**
+     * Constructor method for the UpdateAccount output data
+     * @param useCaseFailed Whether the use case failed or not (i.e. failed updating account)
+     */
+    public UpdateAccountOutputData(boolean useCaseFailed, List<AccountInfo> accounts) {
+        this.useCaseFailed = useCaseFailed;
+        this.accounts = accounts;
+    }
+
+    public List<AccountInfo> getAccounts(){
+        return this.accounts;
+    }
+}

--- a/src/use_case/UpdateAccount/UpdateAccoutOutputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccoutOutputData.java
@@ -1,4 +1,0 @@
-package use_case.UpdateAccount;
-
-public class UpdateAccoutOutputData {
-}

--- a/src/use_case/UpdateAccount/UpdateAccoutOutputData.java
+++ b/src/use_case/UpdateAccount/UpdateAccoutOutputData.java
@@ -1,0 +1,4 @@
+package use_case.UpdateAccount;
+
+public class UpdateAccoutOutputData {
+}

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -63,7 +63,7 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
     private JLabel Notes;
     private JLabel Date;
     private JPanel createAccountPanel;
-    private JPanel updateAccountPanel;
+    private UpdateAccountView updateAccountPanel;
     private JPanel scanItemPanel;
     private JScrollPane tableScrollPane;
 
@@ -138,6 +138,14 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
                 main.add(updateAccountPanel, BorderLayout.CENTER);
                 updateView();
                 setRightPanelName("update account");
+
+                updateAccountPanel.setTitleText(dashboardViewModel.getState().getAccounts().get(rowIndex).getTitle());
+                updateAccountPanel.setUsernameText(dashboardViewModel.getState().getAccounts().get(rowIndex).getUsername());
+                updateAccountPanel.setPasswordText(dashboardViewModel.getState().getAccounts().get(rowIndex).getPassword());
+                updateAccountPanel.set2FAKeyText(dashboardViewModel.getState().getAccounts().get(rowIndex).getSecretKey());
+                updateAccountPanel.setURLText(dashboardViewModel.getState().getAccounts().get(rowIndex).getURL());
+                updateAccountPanel.setIconURLText(dashboardViewModel.getState().getAccounts().get(rowIndex).getIconURL());
+                updateAccountPanel.setNotesText(dashboardViewModel.getState().getAccounts().get(rowIndex).getNotes());
             }
         });
 

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -9,6 +9,9 @@ import interface_adapter.Dashboard.DashboardController;
 import interface_adapter.Dashboard.DashboardState;
 import interface_adapter.Dashboard.DashboardViewModel;
 import interface_adapter.LogOut.LogOutController;
+import interface_adapter.UpdateAccount.UpdateAccountController;
+import interface_adapter.UpdateAccount.UpdateAccountState;
+import interface_adapter.UpdateAccount.UpdateAccountViewModel;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
@@ -58,15 +61,19 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
     private JLabel Notes;
     private JLabel Date;
     private JPanel createAccountPanel;
+    private JPanel updateAccountPanel;
     private JScrollPane tableScrollPane;
 
     public DashboardView(DashboardViewModel dashboardViewModel, DashboardController dashboardController, LogOutController logOutController,
-                         CreateAccountController createAccountController, CreateAccountViewModel createAccountViewModel) {
+                         CreateAccountController createAccountController, CreateAccountViewModel createAccountViewModel,
+                         UpdateAccountController updateAccountController, UpdateAccountViewModel updateAccountViewModel) {
         this.dashboardViewModel = dashboardViewModel;
         this.dashboardController = dashboardController;
         this.logOutController = logOutController;
         this.createAccountPanel = new CreateAccountView(dashboardViewModel, createAccountViewModel, createAccountController);
+        this.updateAccountPanel = new UpdateAccountView(dashboardViewModel ,updateAccountViewModel, updateAccountController);
         this.dashboardViewModel.addPropertyChangeListener(this);
+
 
         this.accountsTableModel = new DefaultTableModel();
         this.accountsTableModel.setColumnIdentifiers(new Object[]{"Icon", "Title", "Username", "URL", "Notes", "Date"});
@@ -98,8 +105,32 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
                 setRightPanelName("create account");
             }
         });
+
+
+        editViewButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int rowIndex = table.getSelectedRow();
+                if (rowIndex == -1){
+                    updateAccountNoAccount();
+                }
+                UpdateAccountState state = updateAccountViewModel.getState();
+                state.setOriginalTitle(dashboardViewModel.getState().getAccounts().get(rowIndex).getTitle());
+                state.setOriginalUser(dashboardViewModel.getState().getAccounts().get(rowIndex).getUsername());
+                updateAccountViewModel.setState(state);
+                main.remove(rightPanel);
+                main.add(updateAccountPanel, BorderLayout.CENTER);
+                updateView();
+                setRightPanelName("update account");
+            }
+        });
+
         this.setLayout(new GridLayout());
         this.add(main);
+    }
+
+    private void updateAccountNoAccount(){
+        JOptionPane.showMessageDialog(this, "no account selected");
     }
 
     private void setRightPanelName(String name){

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -71,7 +71,7 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
                          DashboardController dashboardController, LogOutController logOutController,
                          ScanItemController scanItemController, ScanItemViewModel scanItemViewModel,
                          CreateAccountController createAccountController, CreateAccountViewModel createAccountViewModel,
-                         UpdateAccountController updateAccountController, UpdateAccountViewModel updateAccountViewmodel) {
+                         UpdateAccountController updateAccountController, UpdateAccountViewModel updateAccountViewModel) {
         this.dashboardViewModel = dashboardViewModel;
         this.dashboardController = dashboardController;
         this.logOutController = logOutController;

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -133,6 +133,7 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
                 UpdateAccountState state = updateAccountViewModel.getState();
                 state.setOriginalTitle(dashboardViewModel.getState().getAccounts().get(rowIndex).getTitle());
                 state.setOriginalUser(dashboardViewModel.getState().getAccounts().get(rowIndex).getUsername());
+                state.setUsernameError(null);
                 updateAccountViewModel.setState(state);
                 main.remove(rightPanel);
                 main.add(updateAccountPanel, BorderLayout.CENTER);

--- a/src/view/UpdateAccountView.form
+++ b/src/view/UpdateAccountView.form
@@ -1,13 +1,283 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="view.UpdateAccountView">
-  <grid id="27dc6" row-count="1" column-count="1" layout-manager="GridLayoutManager">
+  <grid id="27dc6" binding="main" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
-      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
     </constraints>
     <properties/>
     <border type="none"/>
-    <children/>
+    <children>
+      <grid id="eded6" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="dc061" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Title          "/>
+            </properties>
+          </component>
+          <component id="85342" class="javax.swing.JTextField" binding="inputTitle">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text value=""/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="5fda3" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <grid id="75f60" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="e2ccf" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Username"/>
+                </properties>
+              </component>
+              <component id="86419" class="javax.swing.JTextField" binding="inputUsername">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+          <grid id="18fe0" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <grid id="4cc8b" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="1f62a" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="Password"/>
+                    </properties>
+                  </component>
+                  <component id="e2596" class="javax.swing.JTextField" binding="inputPassword">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                </children>
+              </grid>
+              <grid id="ea022" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <grid id="d2267" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none"/>
+                    <children>
+                      <component id="e0bcf" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text value="2FAKey   "/>
+                        </properties>
+                      </component>
+                      <component id="95b99" class="javax.swing.JTextField" binding="inputKey">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                            <preferred-size width="150" height="-1"/>
+                          </grid>
+                        </constraints>
+                        <properties/>
+                      </component>
+                    </children>
+                  </grid>
+                  <grid id="49d1c" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none"/>
+                    <children>
+                      <grid id="16c9c" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                        <margin top="0" left="0" bottom="0" right="0"/>
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children>
+                          <component id="ffa65" class="javax.swing.JLabel">
+                            <constraints>
+                              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties>
+                              <text value="URL         "/>
+                            </properties>
+                          </component>
+                          <component id="114f4" class="javax.swing.JTextField" binding="inputURL">
+                            <constraints>
+                              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                                <preferred-size width="150" height="-1"/>
+                              </grid>
+                            </constraints>
+                            <properties/>
+                          </component>
+                        </children>
+                      </grid>
+                      <grid id="63517" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                        <margin top="0" left="0" bottom="0" right="0"/>
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children>
+                          <grid id="a3542" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                            <margin top="0" left="0" bottom="0" right="0"/>
+                            <constraints>
+                              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties/>
+                            <border type="none"/>
+                            <children>
+                              <component id="c726b" class="javax.swing.JLabel">
+                                <constraints>
+                                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                                </constraints>
+                                <properties>
+                                  <text value="IconURL "/>
+                                </properties>
+                              </component>
+                              <component id="582b5" class="javax.swing.JTextField" binding="inputIcon">
+                                <constraints>
+                                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                                    <preferred-size width="150" height="-1"/>
+                                  </grid>
+                                </constraints>
+                                <properties/>
+                              </component>
+                            </children>
+                          </grid>
+                          <grid id="18166" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                            <margin top="0" left="0" bottom="0" right="0"/>
+                            <constraints>
+                              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                            </constraints>
+                            <properties/>
+                            <border type="none"/>
+                            <children>
+                              <grid id="b95f8" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                                <margin top="0" left="0" bottom="0" right="0"/>
+                                <constraints>
+                                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                                </constraints>
+                                <properties/>
+                                <border type="none"/>
+                                <children>
+                                  <component id="a8b16" class="javax.swing.JLabel">
+                                    <constraints>
+                                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties>
+                                      <text value="Notes     "/>
+                                    </properties>
+                                  </component>
+                                  <component id="57e04" class="javax.swing.JTextField" binding="inputNotes">
+                                    <constraints>
+                                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                                        <preferred-size width="150" height="-1"/>
+                                      </grid>
+                                    </constraints>
+                                    <properties/>
+                                  </component>
+                                </children>
+                              </grid>
+                              <grid id="1dc13" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                                <margin top="0" left="0" bottom="0" right="0"/>
+                                <constraints>
+                                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                                </constraints>
+                                <properties/>
+                                <border type="none"/>
+                                <children>
+                                  <component id="84063" class="javax.swing.JButton" binding="updateButton" default-binding="true">
+                                    <constraints>
+                                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties>
+                                      <text value="Update"/>
+                                    </properties>
+                                  </component>
+                                  <component id="cf357" class="javax.swing.JButton" binding="cancelButton" default-binding="true">
+                                    <constraints>
+                                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                                    </constraints>
+                                    <properties>
+                                      <text value="Cancel"/>
+                                    </properties>
+                                  </component>
+                                </children>
+                              </grid>
+                            </children>
+                          </grid>
+                        </children>
+                      </grid>
+                    </children>
+                  </grid>
+                </children>
+              </grid>
+            </children>
+          </grid>
+        </children>
+      </grid>
+    </children>
   </grid>
 </form>

--- a/src/view/UpdateAccountView.form
+++ b/src/view/UpdateAccountView.form
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="view.UpdateAccountView">
+  <grid id="27dc6" row-count="1" column-count="1" layout-manager="GridLayoutManager">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children/>
+  </grid>
+</form>

--- a/src/view/UpdateAccountView.java
+++ b/src/view/UpdateAccountView.java
@@ -52,18 +52,6 @@ public class UpdateAccountView extends JPanel implements ActionListener, Propert
                     updateAccountController.execute( state.getOriginalTitle(), state.getOriginalUser(),
                             state.getTitle(), state.getUsername(), state.getPassword(), state.getSecretKey(),
                             state.getURL(), state.getIconURL(), LocalDateTime.now(), state.getNotes());
-                    inputTitle.setText("");
-                    inputUsername.setText("");
-                    inputPassword.setText("");
-                    inputKey.setText("");
-                    inputURL.setText("");
-                    inputIcon.setText("");
-                    inputNotes.setText("");
-
-                    DashboardState state2 = dashboardViewModel.getState();
-                    state2.setAccounts(null);
-                    dashboardViewModel.setState(state2);
-                    dashboardViewModel.firePropertyChanged();
                 }
 
             }
@@ -80,7 +68,6 @@ public class UpdateAccountView extends JPanel implements ActionListener, Propert
                 setIconURLText("");
                 setNotesText("");
                 updateAccountController.switchView();
-
             }
         });
 
@@ -274,6 +261,15 @@ public class UpdateAccountView extends JPanel implements ActionListener, Propert
             UpdateAccountState updateAccountState = (UpdateAccountState) evt.getNewValue();
             if (updateAccountState.getUsernameError() != null) {
                 JOptionPane.showMessageDialog(this, updateAccountState.getUsernameError());
+            }
+            else {
+                inputTitle.setText("");
+                inputUsername.setText("");
+                inputPassword.setText("");
+                inputKey.setText("");
+                inputURL.setText("");
+                inputIcon.setText("");
+                inputNotes.setText("");
             }
         }
     }

--- a/src/view/UpdateAccountView.java
+++ b/src/view/UpdateAccountView.java
@@ -72,6 +72,13 @@ public class UpdateAccountView extends JPanel implements ActionListener, Propert
         cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                setTitleText("");
+                setUsernameText("");
+                setPasswordText("");
+                set2FAKeyText("");
+                setURLText("");
+                setIconURLText("");
+                setNotesText("");
                 updateAccountController.switchView();
 
             }
@@ -269,5 +276,61 @@ public class UpdateAccountView extends JPanel implements ActionListener, Propert
                 JOptionPane.showMessageDialog(this, updateAccountState.getUsernameError());
             }
         }
+    }
+
+    /**
+     * Method which sets the text of the inputTitle
+     * @param title The title
+     */
+    public void setTitleText(String title) {
+        this.inputTitle.setText(title);
+    }
+
+    /**
+     * Method which sets the text of the inputUsername
+     * @param username The username
+     */
+    public void setUsernameText(String username) {
+        this.inputUsername.setText(username);
+    }
+
+    /**
+     * Method which sets the text of the inputPasword
+     * @param password The password
+     */
+    public void setPasswordText(String password) {
+        this.inputPassword.setText(password);
+    }
+
+    /**
+     * Method which sets the text of the input 2fa key
+     * @param key The 2fa secret key
+     */
+    public void set2FAKeyText(String key) {
+        this.inputKey.setText(key);
+    }
+
+    /**
+     * Method which sets the text of the url input
+     * @param url The url
+     */
+    public void setURLText(String url) {
+        this.inputURL.setText(url);
+    }
+
+    /**
+     * Method which sets the text of the icon url input
+     * @param iconURL The icon's url
+     */
+    public void setIconURLText(String iconURL) {
+        this.inputIcon.setText(iconURL);
+    }
+
+    /**
+     * Method which sets the text of the notes text input
+     * @param notes
+     */
+    public void setNotesText(String notes) {
+        this.inputNotes.setText(notes);
     }
 }

--- a/src/view/UpdateAccountView.java
+++ b/src/view/UpdateAccountView.java
@@ -1,4 +1,273 @@
 package view;
 
-public class UpdateAccountView {
+import interface_adapter.CreateAccount.CreateAccountState;
+import interface_adapter.Dashboard.DashboardState;
+import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.UpdateAccount.UpdateAccountController;
+import interface_adapter.UpdateAccount.UpdateAccountPresenter;
+import interface_adapter.UpdateAccount.UpdateAccountState;
+import interface_adapter.UpdateAccount.UpdateAccountViewModel;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.time.LocalDateTime;
+
+public class UpdateAccountView extends JPanel implements ActionListener, PropertyChangeListener {
+
+
+    public final String viewName = "update account";
+    private final UpdateAccountController updateAccountController;
+    private final DashboardViewModel dashboardViewModel;
+    private final UpdateAccountViewModel updateAccountViewModel;
+    private JTextField inputTitle;
+    private JTextField inputUsername;
+    private JTextField inputPassword;
+    private JTextField inputKey;
+    private JTextField inputURL;
+    private JTextField inputIcon;
+    private JTextField inputNotes;
+    private JButton updateButton;
+    private JButton cancelButton;
+    private JPanel main;
+
+    public UpdateAccountView(DashboardViewModel dashboardViewModel, UpdateAccountViewModel updateAccountViewModel,
+                             UpdateAccountController updateAccountController){
+        this.updateAccountController = updateAccountController;
+        this.updateAccountViewModel = updateAccountViewModel;
+        this.dashboardViewModel = dashboardViewModel;
+        this.updateAccountViewModel.addPropertyChangeListener(this);
+
+        updateButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (e.getSource().equals(updateButton)) {
+                    UpdateAccountState state = updateAccountViewModel.getState();
+
+                    updateAccountController.execute( state.getOriginalTitle(), state.getOriginalUser(),
+                            state.getTitle(), state.getUsername(), state.getPassword(), state.getSecretKey(),
+                            state.getURL(), state.getIconURL(), LocalDateTime.now(), state.getNotes());
+                    inputTitle.setText("");
+                    inputUsername.setText("");
+                    inputPassword.setText("");
+                    inputKey.setText("");
+                    inputURL.setText("");
+                    inputIcon.setText("");
+                    inputNotes.setText("");
+
+                    DashboardState state2 = dashboardViewModel.getState();
+                    state2.setAccounts(null);
+                    dashboardViewModel.setState(state2);
+                    dashboardViewModel.firePropertyChanged();
+                }
+
+            }
+        });
+
+        cancelButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                updateAccountController.switchView();
+
+            }
+        });
+
+        inputTitle.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setTitle(inputTitle.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputUsername.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setUsername(inputUsername.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputPassword.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setPassword(inputPassword.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputKey.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setSecretKey(inputKey.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputURL.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setURL(inputURL.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputIcon.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setIconURL(inputIcon.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+
+        inputNotes.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                // Plain text components don't fire these events
+            }
+
+            private void updateState() {
+                UpdateAccountState currentState = updateAccountViewModel.getState();
+                currentState.setNotes(inputNotes.getText());
+                updateAccountViewModel.setState(currentState);
+            }
+        });
+        this.setLayout(new GridLayout());
+        this.add(main);
+
+
+
+    }
+
+    /**
+     * Invoked when an action occurs.
+     *
+     * @param e the event to be processed
+     */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+
+    }
+
+    /**
+     * This method gets called when a bound property is changed.
+     *
+     * @param evt A PropertyChangeEvent object describing the event source
+     *            and the property that has changed.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        Object state = evt.getNewValue();
+        if (state instanceof UpdateAccountState) {
+            UpdateAccountState updateAccountState = (UpdateAccountState) evt.getNewValue();
+            if (updateAccountState.getUsernameError() != null) {
+                JOptionPane.showMessageDialog(this, updateAccountState.getUsernameError());
+            }
+        }
+    }
 }

--- a/src/view/UpdateAccountView.java
+++ b/src/view/UpdateAccountView.java
@@ -1,0 +1,4 @@
+package view;
+
+public class UpdateAccountView {
+}


### PR DESCRIPTION
This pull request features the addition of the new use case UpdateAccount which updates a user's account info for an already existing account, based on whichever account the user selects in dashboard view. 

There are no additional features in this pull request and it strictly contains the implementations of the appropriate files for the functionality of the Update Account use case.

- User first selects an account from their dashboard view and then presses the editView button
- if no account has been selected, the user is alerted of this with a pop up window
- Once an account has been selected, the user makes their desired changes, and if their updates cause the title and username to be matching with that of another account, another pop up window appears indicating that a duplicate account is trying to be made
- otherwise, the user's account is updated which is reflected on their dashboard view as well as in the database, which was done by passing in an originalTitle and originalUser variable so that in the DAO, the account in the database with the corresponding title and username would have its account details updated with the new inputs if any.
- similar to the other views related to dashboard view, the UpdateAccountView was assigned to the right panel in Dashboard View