### PR TITLE
Delete account - new use case for deleting an account

### DIFF
--- a/src/app/DashboardUseCaseFactory.java
+++ b/src/app/DashboardUseCaseFactory.java
@@ -7,6 +7,9 @@ import interface_adapter.CreateAccount.CreateAccountViewModel;
 import interface_adapter.Dashboard.DashboardController;
 import interface_adapter.Dashboard.DashboardPresenter;
 import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.DeleteAccount.DeleteAccountController;
+import interface_adapter.DeleteAccount.DeleteAccountPresenter;
+import interface_adapter.DeleteAccount.DeleteAccountViewModel;
 import interface_adapter.LogOut.LogOutController;
 import interface_adapter.LogOut.LogOutPresenter;
 import interface_adapter.ViewManagerModel;
@@ -18,6 +21,10 @@ import use_case.Dashboard.DashboardDataAccessInterface;
 import use_case.Dashboard.DashboardInputBoundary;
 import use_case.Dashboard.DashboardInteractor;
 import use_case.Dashboard.DashboardOutputBoundary;
+import use_case.DeleteAccount.DeleteAccountDataAccessInterface;
+import use_case.DeleteAccount.DeleteAccountInputBoundary;
+import use_case.DeleteAccount.DeleteAccountInteractor;
+import use_case.DeleteAccount.DeleteAccountOutputBoundary;
 import use_case.LogOut.LogOutDataAccessInterface;
 import use_case.LogOut.LogOutInputBoundary;
 import use_case.LogOut.LogOutInteractor;
@@ -35,15 +42,17 @@ public class DashboardUseCaseFactory {
     public static DashboardView create(ViewManagerModel viewManagerModel,
                                        AuthenticationViewModel authenticationViewModel,
                                        DashboardViewModel dashboardViewModel, CreateAccountViewModel createAccountViewModel,
-                                       DashboardDataAccessInterface userDataAccessObject) {
+                                       DeleteAccountViewModel deleteAccountViewModel, DashboardDataAccessInterface userDataAccessObject) {
         DashboardController dashboardController = createDashboardUseCase(viewManagerModel, dashboardViewModel,
                 userDataAccessObject);
         LogOutController logOutController = createLogOutUseCase(viewManagerModel, authenticationViewModel,
                 (LogOutDataAccessInterface) userDataAccessObject);
         CreateAccountController createAccountController = createCreateAccountUseCase(viewManagerModel, createAccountViewModel,
                 dashboardViewModel, (CreateAccountDataAccessInterface) userDataAccessObject);
+        DeleteAccountController deleteAccountController = createDeleteAccountUseCase(viewManagerModel, deleteAccountViewModel,
+                dashboardViewModel, (DeleteAccountDataAccessInterface) userDataAccessObject);
         return new DashboardView(dashboardViewModel, dashboardController, logOutController, createAccountController,
-                createAccountViewModel);
+                createAccountViewModel, deleteAccountController);
     }
 
     /**
@@ -96,5 +105,13 @@ public class DashboardUseCaseFactory {
         CreateAccountInputBoundary createAccountUseCaseInteractor = new CreateAccountInteractor(userDataAccessObject, createAccountPresenter);
 
         return new CreateAccountController(createAccountUseCaseInteractor);
+    }
+
+    private static DeleteAccountController createDeleteAccountUseCase(ViewManagerModel viewManagerModel,
+                                                                      DeleteAccountViewModel deleteAccountViewModel, DashboardViewModel dashboardViewModel,
+                                                                      DeleteAccountDataAccessInterface userDataAccessObject) {
+        DeleteAccountOutputBoundary deleteAccountPresenter = new DeleteAccountPresenter(viewManagerModel, deleteAccountViewModel, dashboardViewModel);
+        DeleteAccountInputBoundary deleteAccountUseCaseInteractor = new DeleteAccountInteractor(userDataAccessObject, deleteAccountPresenter);
+        return new DeleteAccountController(deleteAccountUseCaseInteractor);
     }
 }

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -8,6 +8,7 @@ import interface_adapter.Authentication.AuthenticationViewModel;
 import interface_adapter.CreateAccount.CreateAccountController;
 import interface_adapter.CreateAccount.CreateAccountViewModel;
 import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.DeleteAccount.DeleteAccountViewModel;
 import interface_adapter.SetupAuth.SetupAuthViewModel;
 import interface_adapter.ViewManagerModel;
 import view.*;
@@ -42,6 +43,7 @@ public class Main {
         AuthenticationViewModel authenticationViewModel = new AuthenticationViewModel();
         DashboardViewModel dashboardViewModel = new DashboardViewModel();
         CreateAccountViewModel createAccountViewModel = new CreateAccountViewModel();
+        DeleteAccountViewModel deleteAccountViewModel = new DeleteAccountViewModel();
 
         FileAuthDataAccessObject authDataAccessObject;
         FileDashDataAccessObject dashDataAccessObject;
@@ -70,7 +72,7 @@ public class Main {
         views.add(authenticationView, authenticationView.viewName);
 
         DashboardView dashboardView = DashboardUseCaseFactory.create(viewManagerModel, authenticationViewModel,
-                dashboardViewModel, createAccountViewModel, dashDataAccessObject);
+                dashboardViewModel, createAccountViewModel, deleteAccountViewModel, dashDataAccessObject);
         views.add(dashboardView, dashboardView.viewName);
 
 

--- a/src/data_access/FileDashDataAccessObject.java
+++ b/src/data_access/FileDashDataAccessObject.java
@@ -4,6 +4,7 @@ import entity.AccountInfo;
 import entity.AccountInfoFactory;
 import use_case.CreateAccount.CreateAccountDataAccessInterface;
 import use_case.Dashboard.DashboardDataAccessInterface;
+import use_case.DeleteAccount.DeleteAccountDataAccessInterface;
 import use_case.LogOut.LogOutDataAccessInterface;
 
 import javax.crypto.Cipher;
@@ -13,12 +14,9 @@ import java.security.Key;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
+import java.util.*;
 
-public class FileDashDataAccessObject implements DashboardDataAccessInterface, LogOutDataAccessInterface, CreateAccountDataAccessInterface {
+public class FileDashDataAccessObject implements DashboardDataAccessInterface, LogOutDataAccessInterface, CreateAccountDataAccessInterface, DeleteAccountDataAccessInterface {
     private static final String ALGORITHM = "AES";
     private static final String TRANSFORMATION = "AES/ECB/PKCS5Padding";
     private final AccountInfoFactory ACCOUNTFACTORY;
@@ -49,6 +47,31 @@ public class FileDashDataAccessObject implements DashboardDataAccessInterface, L
     public List<AccountInfo> getAccounts() {
         this.retrieveAccounts();
         return this.accounts;
+    }
+
+    /**
+     * Method that deletes an account with a unique title and username combination
+     *
+     * @param title    the title of the account to be deleted
+     * @param username the username of the account to be deleted
+     */
+    @Override
+    public void deleteAccount(String title, String username) {
+        AccountInfo accountToDelete = getAccountFromTitleUsername(title, username);
+        accounts.remove(accountToDelete);
+        String sql = "DELETE FROM password_manager_data WHERE title = ? AND username = ?";
+        try (PreparedStatement statement = CONNECTION.prepareStatement(sql)) {
+            statement.setString(1, encrypt(accountToDelete.getTitle(), this.encryptionKey));
+            statement.setString(2, encrypt(accountToDelete.getUsername(), this.encryptionKey));
+
+            int rowsAffected = statement.executeUpdate();
+
+            if (rowsAffected <= 0) {
+                throw new RuntimeException("No rows were deleted.");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -115,6 +138,22 @@ public class FileDashDataAccessObject implements DashboardDataAccessInterface, L
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Gets the account with the given title and username combination
+     * @param title of account to be retrieved
+     * @param username of account to be retrieved
+     * @return the account with matching title and username (throw RuntimeException if not found)
+     */
+    private AccountInfo getAccountFromTitleUsername(String title, String username) {
+        for (AccountInfo account : accounts) {
+            if (Objects.equals(account.getTitle(), title) && Objects.equals(account.getUsername(), username)) {
+                return account;
+            }
+        }
+
+        throw new RuntimeException("Account with title " + title + " and username " + username + " could not be found and deleted.");
     }
 
     /**

--- a/src/interface_adapter/DeleteAccount/DeleteAccountController.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountController.java
@@ -1,0 +1,2 @@
+package interface_adapter.DeleteAccount;public class DeleteAccountController {
+}

--- a/src/interface_adapter/DeleteAccount/DeleteAccountController.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountController.java
@@ -1,2 +1,36 @@
-package interface_adapter.DeleteAccount;public class DeleteAccountController {
+package interface_adapter.DeleteAccount;
+
+import use_case.DeleteAccount.DeleteAccountInputBoundary;
+import use_case.DeleteAccount.DeleteAccountInputData;
+import use_case.DeleteAccount.DeleteAccountInteractor;
+
+public class DeleteAccountController {
+
+    public final DeleteAccountInputBoundary deleteAccountInteractor;
+
+    /**
+     * Constructor method for the controller for the Delete Account use case
+     * @param deleteAccountInteractor The use case interactor object for the Delete Account use case
+     */
+    public DeleteAccountController(DeleteAccountInputBoundary deleteAccountInteractor) {
+        this.deleteAccountInteractor = deleteAccountInteractor;
+    }
+
+    /**
+     * Method which is executed/triggered when the delete button is clicked
+     * @param title the title of the account to be deleted
+     * @param username the username of the account to be deleted
+     */
+    public void execute(String title, String username) {
+        DeleteAccountInputData inputData = new DeleteAccountInputData(title, username);
+        deleteAccountInteractor.execute(inputData);
+    }
+
+    /**
+     * Method that tells the interactor to switch views
+     */
+    public void switchView(){
+        deleteAccountInteractor.switchView();
+    }
+
 }

--- a/src/interface_adapter/DeleteAccount/DeleteAccountPresenter.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountPresenter.java
@@ -1,0 +1,2 @@
+package interface_adapter.DeleteAccount;public class DeleteAccountPresenter {
+}

--- a/src/interface_adapter/DeleteAccount/DeleteAccountPresenter.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountPresenter.java
@@ -1,2 +1,60 @@
-package interface_adapter.DeleteAccount;public class DeleteAccountPresenter {
+package interface_adapter.DeleteAccount;
+
+import interface_adapter.Dashboard.DashboardState;
+import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.ViewManagerModel;
+import use_case.DeleteAccount.DeleteAccountOutputBoundary;
+import use_case.DeleteAccount.DeleteAccountOutputData;
+
+public class DeleteAccountPresenter implements DeleteAccountOutputBoundary {
+
+    private final DeleteAccountViewModel deleteAccountViewModel;
+    private final DashboardViewModel dashboardViewModel;
+    private ViewManagerModel viewManagerModel;
+
+    /**
+     * Constructor method for the Delete Account use case's presenter
+     * @param viewManagerModel
+     * @param deleteAccountViewModel
+     * @param dashboardViewModel
+     */
+    public DeleteAccountPresenter(ViewManagerModel viewManagerModel, DeleteAccountViewModel deleteAccountViewModel,
+                                  DashboardViewModel dashboardViewModel) {
+        this.viewManagerModel = viewManagerModel;
+        this.deleteAccountViewModel = deleteAccountViewModel;
+        this.dashboardViewModel = dashboardViewModel;
+    }
+
+    /**
+     * Method which updates the view manager model to display the Dashboard screen after Delete Account is complete
+     * @param deleteAccountOutputData The SetupAuth use case output data
+     */
+    @Override
+    public void prepareSuccessView(DeleteAccountOutputData deleteAccountOutputData) {
+        DashboardState dashboardState = dashboardViewModel.getState();
+        dashboardState.setAccounts(deleteAccountOutputData.getAccounts());
+        dashboardViewModel.setState(dashboardState);
+        switchView();
+    }
+
+    /**
+     * Method which updates the view manager model to display the failed Delete Account screen
+     * @param error The error message which explains why Delete Account failed
+     */
+    @Override
+    public void prepareFailView(String error) {
+        // this shouldn't happen I think
+    }
+
+    /**
+     * Switches the view to the dashboard
+     */
+    @Override
+    public void switchView() {
+        DashboardState dashboardState = dashboardViewModel.getState();
+        dashboardState.setRightPanelView("dashboard");
+        dashboardViewModel.setState(dashboardState);
+        this.dashboardViewModel.firePropertyChanged();
+    }
+
 }

--- a/src/interface_adapter/DeleteAccount/DeleteAccountState.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountState.java
@@ -1,2 +1,78 @@
-package interface_adapter.DeleteAccount;public class DeleteAccountState {
+package interface_adapter.DeleteAccount;
+
+import entity.AccountInfo;
+
+import java.util.List;
+
+public class DeleteAccountState {
+
+    private List<AccountInfo> accounts;
+    private String title = "";
+    private String username = "";
+
+    /**
+     * Constructor method for the Delete Account use case's view state
+     * @param copy a copy of the Delete Account's state
+     */
+    public DeleteAccountState(DeleteAccountState copy) {
+        this.accounts = copy.getAccounts();
+        this.title = copy.getTitle();
+        this.username = copy.getUsername();
+    }
+
+    /**
+     * Alternative constructor method for no copy, which keeps null/default values for attributes
+     */
+    public DeleteAccountState() {
+
+    }
+
+    /**
+     * Getter method for the user's accounts
+     * @return the user's accounts
+     */
+    public List<AccountInfo> getAccounts() {
+        return accounts;
+    }
+
+    /**
+     * Setter method for the user's accounts
+     * @param accounts the user's accounts
+     */
+    public void setAccounts(List<AccountInfo> accounts) {
+        this.accounts = accounts;
+    }
+
+    /**
+     * Getter method for the title of the account to delete
+     * @return the title of the account to delete
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Setter method for the title of the account to delete
+     * @param title the title of the account to delete
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * Getter method for the username of the account to delete
+     * @return the username of the account to delete
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Setter method for the username of the account to delete
+     * @param username the username of the account to delete
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
 }

--- a/src/interface_adapter/DeleteAccount/DeleteAccountState.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountState.java
@@ -1,0 +1,2 @@
+package interface_adapter.DeleteAccount;public class DeleteAccountState {
+}

--- a/src/interface_adapter/DeleteAccount/DeleteAccountViewModel.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountViewModel.java
@@ -1,2 +1,52 @@
-package interface_adapter.DeleteAccount;public class DeleteAccountViewModel {
+package interface_adapter.DeleteAccount;
+
+import interface_adapter.ViewModel;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+public class DeleteAccountViewModel extends ViewModel {
+
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
+    private DeleteAccountState state = new DeleteAccountState();
+
+    /**
+     * Constructor method for Delete Account use case
+     */
+    public DeleteAccountViewModel() {
+        super("delete account");
+    }
+
+    /**
+     * method which triggers/executes when the state changes
+     */
+    @Override
+    public void firePropertyChanged() {
+        support.firePropertyChange("state", null, this.state);
+    }
+
+    /**
+     * Method which adds a PropertyChangeListener to the view model
+     * @param listener The PropertyChangeListener to be added
+     */
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        support.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * Getter method for the Delete Account view model's state
+     * @return the Delete Account view model's state
+     */
+    public DeleteAccountState getState() {
+        return this.state;
+    }
+
+    /**
+     * Setter method for the Delete Account view model's state
+     * @param state the Delete Account view model's state
+     */
+    public void setState(DeleteAccountState state) {
+        this.state = state;
+    }
 }

--- a/src/interface_adapter/DeleteAccount/DeleteAccountViewModel.java
+++ b/src/interface_adapter/DeleteAccount/DeleteAccountViewModel.java
@@ -1,0 +1,2 @@
+package interface_adapter.DeleteAccount;public class DeleteAccountViewModel {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountDataAccessInterface.java
+++ b/src/use_case/DeleteAccount/DeleteAccountDataAccessInterface.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountDataAccessInterface {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountDataAccessInterface.java
+++ b/src/use_case/DeleteAccount/DeleteAccountDataAccessInterface.java
@@ -1,2 +1,22 @@
-package use_case.DeleteAccount;public class DeleteAccountDataAccessInterface {
+package use_case.DeleteAccount;
+
+import entity.AccountInfo;
+
+import java.util.List;
+
+public interface DeleteAccountDataAccessInterface {
+
+    /**
+     * Method gets all the currently signed in user's accounts
+     * @return returns list of user's accounts
+     */
+    List<AccountInfo> getAccounts();
+
+    /**
+     * Method that deletes an account with a unique title and username combination
+     * @param title the title of the account to be deleted
+     * @param username the username of the account to be deleted
+     */
+    void deleteAccount(String title, String username);
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
@@ -1,2 +1,11 @@
-package use_case.DeleteAccount;public class DeleteAccountInputBoundary {
+package use_case.DeleteAccount;
+
+public interface DeleteAccountInputBoundary {
+
+    /**
+     * Method which contains the logic for the Delete Account use case (interactor) which is triggered to complete use case
+     * @param deleteAccountInputData The input data for the use case interactor
+     */
+    void execute(DeleteAccountInputData deleteAccountInputData);
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountInputBoundary {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
@@ -8,6 +8,9 @@ public interface DeleteAccountInputBoundary {
      */
     void execute(DeleteAccountInputData deleteAccountInputData);
 
+    /**
+     * Method that tells the
+     */
     void switchView();
 
 }

--- a/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputBoundary.java
@@ -8,4 +8,6 @@ public interface DeleteAccountInputBoundary {
      */
     void execute(DeleteAccountInputData deleteAccountInputData);
 
+    void switchView();
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountInputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputData.java
@@ -1,2 +1,33 @@
-package use_case.DeleteAccount;public class DeleteAccountInputData {
+package use_case.DeleteAccount;
+
+public class DeleteAccountInputData {
+
+    final private String title;
+    final private String username;
+
+    /**
+     * Constructor for the Delete Account use case's input data
+     * @param title of the account to be deleted
+     * @param username of the account to be deleted
+     */
+    public DeleteAccountInputData(String title, String username) {
+        this.title = title;
+        this.username = username;
+    }
+
+    /**
+     * Getter method for the title of the account to be deleted
+     * @return The username of the account.
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Getter method for the username of the account to be deleted
+     * @return The username of the account.
+     */
+    public String getUsername() {
+        return username;
+    }
 }

--- a/src/use_case/DeleteAccount/DeleteAccountInputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInputData.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountInputData {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountInteractor.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInteractor.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountInteractor {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountInteractor.java
+++ b/src/use_case/DeleteAccount/DeleteAccountInteractor.java
@@ -1,2 +1,38 @@
-package use_case.DeleteAccount;public class DeleteAccountInteractor {
+package use_case.DeleteAccount;
+
+import entity.AccountInfo;
+
+public class DeleteAccountInteractor implements DeleteAccountInputBoundary {
+
+    final private DeleteAccountDataAccessInterface dataAccessObject;
+    final private DeleteAccountOutputBoundary deleteAccountPresenter;
+
+    /**
+     * Constructor method for the use case interactor for the Delete Account use case
+     * @param dataAccessObject The data access object which provides access to the stored data required
+     * @param deleteAccountPresenter The presenter for the Delete Account use case
+     */
+    public DeleteAccountInteractor(DeleteAccountDataAccessInterface dataAccessObject,
+                                   DeleteAccountOutputBoundary deleteAccountPresenter) {
+        this.dataAccessObject = dataAccessObject;
+        this.deleteAccountPresenter = deleteAccountPresenter;
+    }
+
+    /**
+     * Method which contains the logic for the Delete Account use case (interactor) which is triggered to complete use case
+     * @param deleteAccountInputData The input data for the Delete Account use case
+     */
+    public void execute(DeleteAccountInputData deleteAccountInputData) {
+        dataAccessObject.deleteAccount(deleteAccountInputData.getTitle(), deleteAccountInputData.getUsername());
+        DeleteAccountOutputData outputData = new DeleteAccountOutputData(false, dataAccessObject.getAccounts());
+        deleteAccountPresenter.prepareSuccessView(outputData);
+    }
+
+    /**
+     * Mehtod to alert the presenter for the Delete Account use case to switch the view
+     */
+    public void switchView() {
+        deleteAccountPresenter.switchView();
+    }
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountOuputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOuputData.java
@@ -1,2 +1,0 @@
-package use_case.DeleteAccount;public class DeleteAccountOuputData {
-}

--- a/src/use_case/DeleteAccount/DeleteAccountOuputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOuputData.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountOuputData {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountOutputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOutputBoundary.java
@@ -1,0 +1,2 @@
+package use_case.DeleteAccount;public class DeleteAccountOutputBoundary {
+}

--- a/src/use_case/DeleteAccount/DeleteAccountOutputBoundary.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOutputBoundary.java
@@ -1,2 +1,19 @@
-package use_case.DeleteAccount;public class DeleteAccountOutputBoundary {
+package use_case.DeleteAccount;
+
+public interface DeleteAccountOutputBoundary {
+
+    /**
+     * Method which updates the view manager model to display the Dashboard screen after Delete Account is complete
+     * @param deleteAccountOutputData The SetupAuth use case output data
+     */
+    void prepareSuccessView(DeleteAccountOutputData deleteAccountOutputData);
+
+    /**
+     * Method which updates the view manager model to display the failed Delete Account screen
+     * @param error The error message which explains why Delete Account failed
+     */
+    void prepareFailView(String error);
+
+    void switchView();
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountOutputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOutputData.java
@@ -18,6 +18,10 @@ public class DeleteAccountOutputData {
         this.accounts = accounts;
     }
 
+    /**
+     * Getter method for the in-memory list of accounts
+     * @return the list of accounts
+     */
     public List<AccountInfo> getAccounts(){
         return this.accounts;
     }

--- a/src/use_case/DeleteAccount/DeleteAccountOutputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOutputData.java
@@ -1,4 +1,25 @@
 package use_case.DeleteAccount;
 
-public class DeleteAccountOuputData {
+import entity.AccountInfo;
+
+import java.util.List;
+
+public class DeleteAccountOutputData {
+
+    private final boolean useCaseFailed;
+    private List<AccountInfo> accounts;
+
+    /**
+     * Constructor method for the Delete Account output data
+     * @param useCaseFailed Whether the use case failed or not (i.e. failed deleting account)
+     */
+    public DeleteAccountOutputData(boolean useCaseFailed, List<AccountInfo> accounts) {
+        this.useCaseFailed = useCaseFailed;
+        this.accounts = accounts;
+    }
+
+    public List<AccountInfo> getAccounts(){
+        return this.accounts;
+    }
+
 }

--- a/src/use_case/DeleteAccount/DeleteAccountOutputData.java
+++ b/src/use_case/DeleteAccount/DeleteAccountOutputData.java
@@ -1,0 +1,4 @@
+package use_case.DeleteAccount;
+
+public class DeleteAccountOuputData {
+}

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -8,9 +8,12 @@ import interface_adapter.CreateAccount.CreateAccountViewModel;
 import interface_adapter.Dashboard.DashboardController;
 import interface_adapter.Dashboard.DashboardState;
 import interface_adapter.Dashboard.DashboardViewModel;
+import interface_adapter.DeleteAccount.DeleteAccountController;
 import interface_adapter.LogOut.LogOutController;
 
 import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -19,12 +22,16 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class DashboardView extends JPanel implements ActionListener, PropertyChangeListener {
 
     public final String viewName = "display dash";
     private final DashboardController dashboardController;
     private final LogOutController logOutController;
+    private final DeleteAccountController deleteAccountController;
     private final DashboardViewModel dashboardViewModel;
     private JButton mainView;
     private DefaultTableModel accountsTableModel;
@@ -61,10 +68,11 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
     private JScrollPane tableScrollPane;
 
     public DashboardView(DashboardViewModel dashboardViewModel, DashboardController dashboardController, LogOutController logOutController,
-                         CreateAccountController createAccountController, CreateAccountViewModel createAccountViewModel) {
+                         CreateAccountController createAccountController, CreateAccountViewModel createAccountViewModel, DeleteAccountController deleteAccountController) {
         this.dashboardViewModel = dashboardViewModel;
         this.dashboardController = dashboardController;
         this.logOutController = logOutController;
+        this.deleteAccountController = deleteAccountController;
         this.createAccountPanel = new CreateAccountView(dashboardViewModel, createAccountViewModel, createAccountController);
         this.dashboardViewModel.addPropertyChangeListener(this);
 
@@ -100,6 +108,22 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
         });
         this.setLayout(new GridLayout());
         this.add(main);
+
+        deleteButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                // Loops through selected rows and deletes accounts (implicitly does nothing if no rows are selected)
+                List<String> titlesToDelete = new ArrayList<>();
+                List<String> usernamesToDelete = new ArrayList<>();
+                for (int row : table.getSelectedRows()) {
+                    titlesToDelete.add((String) table.getValueAt(row, 1));
+                    usernamesToDelete.add((String) table.getValueAt(row, 2));
+                }
+                for (int i = 0; i < titlesToDelete.toArray().length; i++) {
+                    deleteAccountController.execute(titlesToDelete.get(i), usernamesToDelete.get(i));
+                }
+            }
+        });
     }
 
     private void setRightPanelName(String name){

--- a/src/view/DashboardView.java
+++ b/src/view/DashboardView.java
@@ -112,18 +112,21 @@ public class DashboardView extends JPanel implements ActionListener, PropertyCha
         deleteButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                // Loops through selected rows and deletes accounts (implicitly does nothing if no rows are selected)
-                List<String> titlesToDelete = new ArrayList<>();
-                List<String> usernamesToDelete = new ArrayList<>();
-                for (int row : table.getSelectedRows()) {
-                    titlesToDelete.add((String) table.getValueAt(row, 1));
-                    usernamesToDelete.add((String) table.getValueAt(row, 2));
-                }
-                for (int i = 0; i < titlesToDelete.toArray().length; i++) {
-                    deleteAccountController.execute(titlesToDelete.get(i), usernamesToDelete.get(i));
+                // Gets most recent
+                int rowIndex = table.getSelectedRow();
+                if (rowIndex == -1){
+                    deleteAccountNoAccount();
+                } else {
+                    String titleToDelete = (String) table.getValueAt(rowIndex, 1);
+                    String usernameToDelete = (String) table.getValueAt(rowIndex, 2);
+                    deleteAccountController.execute(titleToDelete, usernameToDelete);
                 }
             }
         });
+    }
+
+    private void deleteAccountNoAccount() {
+        JOptionPane.showMessageDialog(this, "no account selected");
     }
 
     private void setRightPanelName(String name){


### PR DESCRIPTION
This pull request features the addition of the new use case UpdateAccount which deletes the selected account(s) from the database and reloads the dashboard view to reflect that.

There are no additional features in this pull request and it strictly contains the implementations of the appropriate files for the functionality of the Delete account use case.

- When the delete button in the Dashboard View is pressed, the listener for that button checks to see what elements of the accounts table were highlighted, and saves the titles and usernames of the highlighted account(s) to lists
- Then, the listener loops through the list, using the controller's execute method on each pair of title and username. This sends it through Clean Architecture to interact with other parts of the program, such as the in-memory data and the database
- The execute method uses an SQL command to remove the accounts from the databse, based off of their unique title and username pair, and also removes the accounts from the application's in-memory list of accounts, and then reloads the Dashboard View to reflect the changes

All newly added files and methods were documented with Javadocs, and comments were added where applicable. It is a fairly straightforward application of Clean Architecture.